### PR TITLE
Don't break when values are null

### DIFF
--- a/src/record.js
+++ b/src/record.js
@@ -25,7 +25,7 @@ class Record {
 			return this._values[index].toString();
 		}
 		
-		return '';
+		return null;
 		
 		
 	}

--- a/src/record.js
+++ b/src/record.js
@@ -20,7 +20,14 @@ class Record {
 		if (typeof key === "string") {
 			index = this._header.indexOf(key);
 		}
-		return this._values[index].toString();
+		
+		if (this._values[index]) {
+			return this._values[index].toString();
+		}
+		
+		return '';
+		
+		
 	}
 
 	keys() {

--- a/src/record.js
+++ b/src/record.js
@@ -26,8 +26,6 @@ class Record {
 		}
 		
 		return null;
-		
-		
 	}
 
 	keys() {


### PR DESCRIPTION
Some values can be empty, which leaves them with a null value.

For example, 'n.notHere' will be null.

Now, running .toString on null throws an error. 
This fix mitigates the error.

Yet I'm unsure what the return type should be in case of a null value. null? an empty string? Please advise!