### PR TITLE
Add support for multi-labeled nodes

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -7,12 +7,12 @@ class Node {
     /**
      * Builds a node object.
 	 *
-     * @param {string} label - node label.
+     * @param {string|string[]} label - node label(s).
      * @param {Map} properties - properties map.
      */
 	constructor(label, properties) {
 		this.id = undefined;            //node's id - set by RedisGraph
-		this.label = label;             //node's label
+		this.label = label;             //node's label(s)
 		this.properties = properties;   //node's list of properties (list of Key:Value)
 	}
 

--- a/types/src/edge.d.ts
+++ b/types/src/edge.d.ts
@@ -32,4 +32,4 @@ declare class Edge {
 declare namespace Edge {
     export { Node };
 }
-type Node = import("./node");
+type Node = import('./node');

--- a/types/src/graph.d.ts
+++ b/types/src/graph.d.ts
@@ -1,5 +1,8 @@
 export = Graph;
 /**
+ * @typedef {import('ioredis') | redis.RedisClient} RedisClient
+ */
+/**
  * RedisGraph client
  */
 declare class Graph {
@@ -8,11 +11,11 @@ declare class Graph {
      * See: node_redis for more options on createClient
      *
      * @param {string} graphId the graph id
-     * @param {string | redis.RedisClient} [host] Redis host or node_redis client
+     * @param {string | RedisClient} [host] Redis host or node_redis client or ioredis client
      * @param {string | number} [port] Redis port (integer)
      * @param {Object} [options] node_redis options
      */
-    constructor(graphId: string, host?: string | any, port?: string | number, options?: any);
+    constructor(graphId: string, host?: string | RedisClient, port?: string | number, options?: any);
     _graphId: string;
     _labels: any[];
     _relationshipTypes: any[];
@@ -53,6 +56,26 @@ declare class Graph {
      * @returns {Promise<ResultSet>} a promise contains a result set
      */
     query(query: string, params?: Map<any, any>): Promise<ResultSet>;
+    /**
+     * Execute a Cypher readonly query
+     * @async
+     * @param {string} query Cypher query
+     * @param {Map} [params] Parameters map
+     *
+     * @returns {Promise<ResultSet>} a promise contains a result set
+     */
+    readonlyQuery(query: string, params?: Map<any, any>): Promise<ResultSet>;
+    /**
+     * Execute a Cypher query
+     * @private
+     * @async
+     * @param {'graph.QUERY'|'graph.RO_QUERY'} command
+     * @param {string} query Cypher query
+     * @param {Map} [params] Parameters map
+     *
+     * @returns {Promise<ResultSet>} a promise contains a result set
+     */
+    private _query;
     /**
      * Deletes the entire graph
      * @async
@@ -122,4 +145,8 @@ declare class Graph {
      */
     fetchAndGetProperty(id: number): Promise<string>;
 }
+declare namespace Graph {
+    export { RedisClient };
+}
 import ResultSet = require("./resultSet");
+type RedisClient = any | any;

--- a/types/src/node.d.ts
+++ b/types/src/node.d.ts
@@ -6,12 +6,12 @@ declare class Node {
     /**
      * Builds a node object.
      *
-     * @param {string} label - node label.
+     * @param {string|string[]} label - node label(s).
      * @param {Map} properties - properties map.
      */
-    constructor(label: string, properties: Map<any, any>);
+    constructor(label: string | string[], properties: Map<any, any>);
     id: number;
-    label: string;
+    label: string | string[];
     properties: Map<any, any>;
     /**
      * Sets the node id.

--- a/types/src/path.d.ts
+++ b/types/src/path.d.ts
@@ -64,5 +64,5 @@ declare class Path {
 declare namespace Path {
     export { Node, Edge };
 }
-type Node = import("./node");
-type Edge = import("./edge");
+type Node = import('./node');
+type Edge = import('./edge');

--- a/types/src/resultSet.d.ts
+++ b/types/src/resultSet.d.ts
@@ -51,6 +51,13 @@ declare class ResultSet {
      */
     parseEntityProperties(props: object[]): Promise<object>;
     /**
+     * Parse label index into a label string
+     * @async
+     * @param {number} label_idx index of label
+     * @returns {Promise<string>} string representation of label.
+     */
+    parseNodeLabel(label_idx: number): Promise<string>;
+    /**
      * Parse raw node representation into a Node object.
      * @async
      * @param {object[]} cell raw node representation.
@@ -85,6 +92,15 @@ declare class ResultSet {
      * @returns {Promise<object>} Map object.
      */
     parseMap(rawMap: object[]): Promise<object>;
+    /**
+     * Parse a raw Point representation into a lat-lon Map object.
+     * @param {object[]} rawPoint 2-valued lat-lon array representation
+     * @returns {{ latitude: number, longitude: number }} Map object with latitude and longitude keys.
+     */
+    parsePoint(rawPoint: object[]): {
+        latitude: number;
+        longitude: number;
+    };
     /**
      * Parse a raw value into its actual value.
      * @async
@@ -121,4 +137,4 @@ import Node = require("./node");
 import Edge = require("./edge");
 import Path = require("./path");
 import Record = require("./record");
-type Graph = import("./graph");
+type Graph = import('./graph');


### PR DESCRIPTION
This PR allows nodes to be created and parsed with an array of label string as well as with a label string (for backwards compatibility).

This should not break existing functionality, but adds the ability to have multiple labels on a given node.